### PR TITLE
Fix clone URL in README and remove stdlib asyncio from requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 Clone the repository and run the automated installer:
 
 ```bash
-git clone https://github.com/saadsh15/ai-council.git
+git clone https://github.com/saadsh15/ai_council.git
 cd ai-council
 bash scripts/install.sh
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ textual
 httpx
 pyyaml
 rich
-asyncio
 python-dotenv
 pydantic
 numpy


### PR DESCRIPTION
**Changes:**

1. **README.md** Fixed the clone URL from `ai-council` (hyphen) to `ai_council` (underscore) to match the actual repo name. The old URL would 404 for anyone following the installation instructions.

2. **requirements.txt** Removed `asyncio` which is part of the Python standard library since 3.4. Installing it via pip on Python 3.12+ can shadow the built-in module and cause import errors.

Fixes #3, Fixes #4